### PR TITLE
Fix spec for v7

### DIFF
--- a/nethserver-ipsec.spec
+++ b/nethserver-ipsec.spec
@@ -26,9 +26,9 @@ mkdir -p root%{perl_vendorlib}
 mv -v lib/perl/NethServer root%{perl_vendorlib}
 
 %install
-rm -rf $RPM_BUILD_ROOT
-(cd root; find . -depth -print | cpio -dump $RPM_BUILD_ROOT)
-%{genfilelist} $RPM_BUILD_ROOT \
+rm -rf %{buildroot}
+(cd root; find . -depth -print | cpio -dump %{buildroot})
+%{genfilelist} %{buildroot} \
    --file /etc/ipsec.d/nsspassword 'attr(0600,root,root)' \
   > %{name}-%{version}-filelist
 echo "%doc COPYING" >> %{name}-%{version}-filelist


### PR DESCRIPTION
Refs NethServer/dev#5000
The v7 branch is not present.
An IPsec tunnel can be created, but I couldn't test it (remote endpoint missing).

Warnings found in /var/log/messages:

Dec 29 15:54:04 ns7a1 ipsec_starter[16571]: leftsourceip= used but not leftsubnet= defined, defaulting leftsubnet to 192.168.5.125
Dec 29 15:54:04 ns7a1 ipsec_starter[16571]: conn: "aaa_ipsec-tunnel/1x1" warning dpd settings are ignored unless both dpdtimeout= and dpddelay= are set
