### PR TITLE
Drop conn %default definition

### DIFF
--- a/root/etc/e-smith/templates/etc/ipsec.conf/00template_vars
+++ b/root/etc/e-smith/templates/etc/ipsec.conf/00template_vars
@@ -2,8 +2,8 @@
     #
     # 00template_vars
     #
- 
-    use esmith::AccountsDB;   
+
+    use esmith::AccountsDB;
     use esmith::NetworksDB;
     use esmith::ConfigDB;
     use esmith::util;
@@ -13,16 +13,14 @@
     $vpnsDb = esmith::ConfigDB->open("vpn") || die("Could not open VPN DB");
 
     $conn = {
-	'%default' => {
-	    'type' => 'tunnel',
-	}
+
     };
 
     @localNetworks = ();
 
     foreach ($networksDb->green()) {
 	push @localNetworks, esmith::util::computeLocalNetworkShortSpec(
-	    $_->prop('ipaddr'), 
+	    $_->prop('ipaddr'),
 	    $_->prop('netmask')
 	    );
     }

--- a/root/etc/e-smith/templates/etc/ipsec.conf/20authby
+++ b/root/etc/e-smith/templates/etc/ipsec.conf/20authby
@@ -1,25 +1,6 @@
 {
     #
-    # 20authby
+    # 20authby -- moved into 20l2tp
     #
-
-    my $authBy;
-
-    if($ipsec{'KeyType'} eq 'psk') {
-	$authBy = 'secret';
-        $conn->{'%default'}->{'leftid'} = '@' . ( $ipsec{'AuthenticationId'} || join('.', $SystemName, $DomainName) );
-    } else {
-	my $certName = $ipsec{'KeyRsaName'} || join('.', $SystemName, $DomainName);
-
-	$conn->{'%default'}->{'leftcert'} = $certName;
-	$conn->{'%default'}->{'leftrsasigkey'} = '%cert';
-        $conn->{'%default'}->{'leftid'} = '%fromcert';
-
-	$authBy = 'rsasig';
-    } 
-
-    $conn->{'%default'}->{'authby'} = $authBy;
-
-
     '';
 }

--- a/root/etc/e-smith/templates/etc/ipsec.conf/20l2tp
+++ b/root/etc/e-smith/templates/etc/ipsec.conf/20l2tp
@@ -10,14 +10,30 @@
         return '';
     }
 
+    my %defaults = ();
+
+    if($ipsec{'KeyType'} eq 'psk') {
+       $defaults{'authby'} = 'secret';
+       $defaults{'leftid'} = '@' . ( $ipsec{'AuthenticationId'} || join('.', $SystemName, $DomainName) );
+    } else {
+       my $certName = $ipsec{'KeyRsaName'} || join('.', $SystemName, $DomainName);
+       $defaults{'leftcert'} = $certName;
+       $defaults{'leftrsasigkey'} = '%cert';
+       $defaults{'leftid'} = '%fromcert';
+       $defaults{'authby'} = 'rsasig';
+    }
+
     # L2TP connections
     foreach ($ndb->red()) {
-        $conn->{'~L2TP'.$_->key} = {
+        $conn->{'~L2TP' . $_->key} = {
+            %defaults,
+
             'auto' => 'add',
             'pfs' => 'no',
+            'rekey' => 'no',
 
             'left' => '%'.$_->key,
-            'leftprotoport' => '17/%any',
+            'leftprotoport' => '17/1701',
 
             'right' => '%any',
             'rightprotoport' => '17/%any',
@@ -25,11 +41,11 @@
             'ikelifetime' => '8h',
             'keylife' => '1h',
 
-            'dpddelay' => '30',
-            'dpdtimeout' => '120',
+            'dpddelay' => '10',
+            'dpdtimeout' => '90',
             'dpdaction' => 'clear',
 
-        'type' => 'transport',
+            'type' => 'transport',
         };
     }
 


### PR DESCRIPTION
All %default parameters are transfered into L2TP connection definition.
This should fix any parameter conflict with net2net tunnels.

L2TP parameters settings have been backported from v7 branch.
